### PR TITLE
Fix broken checks for missing pygments module

### DIFF
--- a/r2wiki.py
+++ b/r2wiki.py
@@ -7,9 +7,6 @@ import sys
 import pydoc
 from argparse import ArgumentParser
 from subprocess import Popen, PIPE
-from pygments import highlight
-from pygments.lexers import MarkdownLexer
-from pygments.formatters import TerminalFormatter
 
 black_list = ['<p hidden>', '<!--', '<img src']
 src_dir = os.path.dirname(os.path.realpath(__file__))
@@ -56,7 +53,9 @@ else:
                          flags=re.IGNORECASE)
 
 try:
-
+    from pygments import highlight
+    from pygments.lexers import MarkdownLexer
+    from pygments.formatters import TerminalFormatter
     found = ''
 
     for path, subdirs, files in os.walk(src_dir):


### PR DESCRIPTION
Since the module was imported outside the try the exception was never
caught and correct fix message was not displayed.

On a system where pygments is not installed running r2wiki.py results in error on line 10; ImportError: No module named pygments;
With a fix it displays "Pygments dependency not met. pip install Pygments"