### PR TITLE
Update radare2 command line history path

### DIFF
--- a/home/tips.md
+++ b/home/tips.md
@@ -46,7 +46,7 @@
 	- `r2pm -i keystone-lib`
 	- `r2pm -i keystone`
 	- And then invoke with either `r2 -a arm.ks` or from shell `e asm.assembler = arm.ks`
-- The radare2 command line history can be found in `$HOME/.config/radare2/history`
+- The radare2 command line history can be found in `$HOME/.cache/radare2/history`
 - You can use rarun profile paramaters directly using `radare2 -R [arg1=foo] [stdin=bar] [preload=baz] -d binary`
 - To find addresses of all functions, use `s @@f`
 - To search for something in memory, use `/v` in conjuction with `e search.in=dbg.maps`


### PR DESCRIPTION
I'm not sure when (or if) the history file's path changed, but it's in the `$HOME/.cache` directory [according to the current source](https://github.com/radare/radare2/blob/bb67b54f740a08b4e45f16fb4b1e2e3454fbbe11/libr/include/r_userconf.h.acr#L79).